### PR TITLE
Increase upper bound on `QuickCheck`

### DIFF
--- a/OrderedBits.cabal
+++ b/OrderedBits.cabal
@@ -84,7 +84,7 @@ test-suite properties
                     , ScopedTypeVariables
   build-depends: base
                , OrderedBits
-               , QuickCheck         >= 2.7  &&  < 2.9
+               , QuickCheck         >= 2.7  &&  < 2.10
                , tasty              >= 0.11
                , tasty-quickcheck   >= 0.8
                , tasty-th           >= 0.1


### PR DESCRIPTION
`OrderedBits` builds against `QuickCheck-2.9.2` and tests pass